### PR TITLE
Remove PDFs from publish directory

### DIFF
--- a/Habitats/MarsGummiHaus/publish/Cost_Estimation_Mars_Project_EN.md
+++ b/Habitats/MarsGummiHaus/publish/Cost_Estimation_Mars_Project_EN.md
@@ -1,0 +1,126 @@
+---
+title: "Cost Estimation for Test Project on Earth and First Building Project on Mars"
+author: "Robert Alexander Massinger"
+date: 2024-06-01
+keywords: [Mars, Cost Estimation, Habitat]
+abstract: |
+  This document provides approximate cost estimates for constructing a prototype on Earth and the first rubber-glass building on Mars. Estimates include materials, assembly, transport, and certification with contingencies for unforeseen challenges.
+license: CC BY 4.0
+---
+To provide reasonable cost estimations for both the **Test Project on Earth** and the **First Building Project on Mars**, we'll make assumptions about costs related to materials, assembly, transport (in the case of Mars), and certification. These estimates will focus on medium-range costs with the necessary contingencies for unforeseen challenges. All costs are in USD and assume current technology and prices.
+
+---
+
+### 1. **Test Project on Earth**
+
+This project will involve building a full-scale prototype on Earth to test materials and certify the structural integrity and engineering of the rubber-glass house. This project would exclude interiors but would serve as the basis for validating the Mars design.
+
+#### **Estimated Costs for Earth-based Test Project:**
+- **Silicone rubber and additives:**  
+  - Cost: ~$50,000  
+  - Comments: Materials sourced locally, includes prototyping and slight overages for testing.
+
+- **Titanium/Inconel frame:**  
+  - Cost: ~$175,000  
+  - Comments: Titanium and Inconel are expensive, but Earth-based manufacturing benefits from established supply chains and technologies.
+
+- **Borosilicate glass (with insulation):**  
+  - Cost: ~$450,000  
+  - Comments: Pricing is slightly lower than Mars due to ease of local fabrication.
+
+- **Solar panels for the roof:**  
+  - Cost: ~$200,000  
+  - Comments: Standard high-efficiency solar panels, including some custom work for design integration.
+
+- **Airlock (Titanium/Inconel & Borosilicate):**  
+  - Cost: ~$120,000  
+  - Comments: Prototyping a functional airlock to simulate Martian conditions.
+
+- **Manufacturing and assembly on Earth:**  
+  - Cost: ~$300,000  
+  - Comments: Includes labor, equipment, and custom engineering solutions. Could be cheaper if using automated or prefabricated methods.
+
+- **Testing, certification, and validation (Earth environment):**  
+  - Cost: ~$400,000  
+  - Comments: Extensive testing, including structural integrity, thermal resistance, airtightness, and durability.
+
+- **Interior (medium-range budget for labs, living spaces, etc.):**  
+  - Cost: ~$200,000  
+  - Comments: Basic interior build-out, equivalent to a medium-range, concrete-based setup.
+
+#### **Total Estimated Cost for Earth Test Project:**  
+**~$1,895,000**
+
+---
+
+### 2. **First Building Project on Mars (Including Transport)**
+
+This includes building the structure on Mars with all necessary transportation and construction considerations. All costs assume current transportation costs to Mars and exclude the interiors, which would be addressed separately.
+
+#### **Estimated Costs for Mars Project (Excluding Interiors):**
+
+- **Silicone rubber and additives (local production potential):**  
+  - Cost: ~$75,000  
+  - Comments: If silicone rubber can be partially manufactured from Martian resources, this cost could decrease. Otherwise, transport of this material would increase the cost significantly.
+
+- **Titanium/Inconel frame (including transport):**  
+  - Material cost: ~$175,000  
+  - Transport cost: ~$10,000,000  
+  - Comments: Given the high weight of these materials, transportation would dominate the cost. The price assumes SpaceX or a comparable provider offering lower-cost Mars missions ($2,700/kg).
+
+- **Borosilicate glass (including transport):**  
+  - Material cost: ~$500,000  
+  - Transport cost: ~$27,000,000  
+  - Comments: Borosilicate glass is heavy, and transporting 10,000 kg at ~$2,700/kg results in substantial costs.
+
+- **Solar panels (including transport):**  
+  - Material cost: ~$200,000  
+  - Transport cost: ~$2,000,000  
+  - Comments: Solar panels are lighter than glass but still expensive to transport in large quantities. There may be opportunities to produce some materials locally on Mars in the future.
+
+- **Airlock (including transport):**  
+  - Material cost: ~$120,000  
+  - Transport cost: ~$2,700,000  
+  - Comments: The airlock is a crucial element that must be transported in a durable form. The cost reflects its weight and specialized nature.
+
+- **Manufacturing and assembly on Mars (robotics and human assistance):**  
+  - Cost: ~$2,000,000  
+  - Comments: Includes costs for deploying robotic construction teams, supervision, and other logistical challenges unique to Mars.
+
+- **Interior (excluded from transport):**  
+  - Cost: ~$300,000  
+  - Comments: This is an estimate for fitting out interiors with medium-range construction, similar to what you might expect from typical Earth-based housing, adjusted for Martian conditions.
+
+#### **Total Estimated Cost for First Mars Project (Excluding Interiors):**  
+**~$44,870,000**
+
+---
+
+### Breakdown Comparison
+
+| **Cost Category**         | **Earth Test Project** | **First Mars Project (Including Transport)** |
+|---------------------------|------------------------|----------------------------------------------|
+| Silicone Rubber & Additives| ~$50,000               | ~$75,000                                     |
+| Titanium/Inconel Frame     | ~$175,000              | ~$10,175,000                                 |
+| Borosilicate Glass         | ~$450,000              | ~$27,500,000                                 |
+| Solar Panels               | ~$200,000              | ~$2,200,000                                  |
+| Airlock                    | ~$120,000              | ~$2,820,000                                  |
+| Manufacturing & Assembly   | ~$300,000              | ~$2,000,000                                  |
+| Testing & Certification    | ~$400,000              | ~$300,000                                    |
+| Interior (medium-range)    | ~$200,000              | ~$300,000 (excluded from transport)          |
+| **Total**                  | **~$1,895,000**        | **~$44,870,000**                             |
+
+---
+
+### Conclusion:
+
+1. **Earth Test Project (~$1.9 million):**  
+   This project involves creating a prototype on Earth to certify the materials, design, and processes. It's an essential step to de-risk the larger Mars mission and fine-tune the construction methods and materials.
+
+2. **First Mars Building (~$44.9 million):**  
+   The significant cost comes from the transportation of heavy materials like titanium, Inconel, and borosilicate glass. As transportation costs drop and more materials can be sourced locally on Mars, these costs could decrease, but current estimates place transportation as the overwhelming expense.
+
+
+---
+**License:** CC BY 4.0
+**Disclaimer:** Portions of this document were generated with the assistance of GPT-4.

--- a/Habitats/MarsGummiHaus/publish/Design_Rubber-Glass_House_Mars_EN.md
+++ b/Habitats/MarsGummiHaus/publish/Design_Rubber-Glass_House_Mars_EN.md
@@ -1,0 +1,109 @@
+---
+title: "Design of a 1000 m² Rubber-Glass House for Mars"
+author: "Robert Alexander Massinger"
+date: 2024-06-01
+keywords: [Mars, Habitat, Rubber-Glass House, Architecture]
+abstract: |
+  This proposal outlines a 1000 m² rubber-glass house designed for Mars. It relies on locally produced silicone rubber and a titanium or Inconel frame with borosilicate glass to create a resilient and scalable habitat for future Martian colonies.
+license: CC BY 4.0
+---
+**Proposal: Design of a 1000 m² Rubber-Glass House for Mars**
+
+Dear Sir or Madam,  
+Mars represents the next great frontier of human exploration. To successfully advance the settlement of Mars, the development of innovative, sustainable, and safe habitats is crucial. We present to you a unique concept: a 1000 m² rubber-glass house, specifically designed for the extreme conditions of Mars. This project offers an exceptional investment opportunity in the future of space travel and extraterrestrial colonization.
+
+### 1. Concept and Design
+
+**Floor Plan and Structure**
+- **Total Area:** 1000 m² (50 m x 20 m)
+- **Height:** 3 m, sufficient for living and working spaces
+
+**Materials**
+- **Rubber floor slab and foundation wall:** Cast from silicone rubber on-site
+- **Frame:** High-strength titanium or Inconel structure
+- **Glazing:** Borosilicate glass with an insulation layer
+- **Roof:** Solar panels for energy generation
+- **Airlock:** Titanium/Inconel construction with borosilicate glass
+
+### 2. Detailed Description
+
+**Rubber Floor Slab and Foundation Wall**
+- **Material:** Silicone rubber to ensure flexibility and airtightness
+- **Dimensions:**
+  - Floor slab: 1000 m², thickness 10 cm
+  - Foundation wall: 140 m circumference, 50 cm height, 10 cm thickness
+- **Volume:** 107 m³ of silicone rubber
+
+**Titanium or Inconel Frame**
+- **Weight:** 5500 kg including fastenings (rivets or screws)
+- **Advantages:** Excellent corrosion resistance, high strength, and thermal stability
+
+**Borosilicate Glass with Insulation Layer**
+- **Area:** 1000 m²
+- **Weight:** 10,000 kg
+- **Coatings:** Anti-reflective and UV protection coatings to improve energy efficiency and durability
+
+**Solar Panels on the Roof**
+- **Area:** 1000 m²
+- **Energy Generation:** Stable at approximately 973,392 kWh per Martian year, enough to supply the living areas and systems
+
+**Airlock**
+- **Dimensions:** 2 m x 2 m x 5 m
+- **Weight:** approx. 1000 kg
+- **Material:** Titanium/Inconel and borosilicate glass
+
+### 3. Internal Equipment
+
+**Agricultural Areas and CO2 Conversion**
+- **Agricultural Area:** 50 m² per person, totaling 200 m² for a vegan diet
+- **Plants:** Vegetables, fruits, legumes, grains
+- **CO2 to O2 Conversion:** Plants and algae reactors, area approx. 20 m²
+
+**Living Quarters and Laboratories**
+- **Layout:** Living areas, laboratories, and machinery room for up to 4 people
+- **Facilities:** Modern equipment to ensure livelihood and research
+
+### 4. Sustainability and Efficiency
+
+**Utilization of Locally Produced Materials**
+- **Silicone rubber and silicate glass:** Manufactured from Martian rock and silicon dioxide
+- **Metals:** Long-term use of Martian minerals for the extraction of titanium and aluminum
+
+### 5. Cost Estimate (Excluding Transport Costs)
+- **Silicone rubber and additives:** approx. $53,500
+- **Titanium/Inconel frame:** approx. $165,000
+- **Borosilicate glass:** approx. $500,000
+- **Solar panels:** approx. $200,000
+- **Airlock:** approx. $100,000
+- **Total (materials):** approx. $1,018,500
+- **Manufacturing and assembly:** approx. $300,000
+- **Testing and validation:** approx. $200,000
+- **Total cost:** approx. $1,518,500
+
+### 6. Market Potential and Investment Opportunities
+
+**Investor Benefits**
+- **Technology Leadership:** Positioning as a pioneer in Mars colonization and space technology.
+- **Sustainability:** The use of locally available resources reduces long-term costs and dependence on Earth-based supplies.
+- **Growth Market:** Increasing demand for extraterrestrial habitats and infrastructure.
+
+**Long-term Vision**
+- **Self-sufficiency:** Reduction of transport costs through locally produced building materials and resources.
+- **Expansion:** Opportunity to scale the project for larger colonies and commercial applications.
+
+### 7. Conclusion
+
+The rubber-glass house offers a groundbreaking solution for living and working on Mars. With a well-thought-out combination of advanced materials and sustainable technologies, this concept represents a significant step toward permanent Martian colonies. Investors have the unique opportunity to be part of a revolutionary project that will not only shape Mars exploration but also have a lasting impact on the entire space industry.  
+We warmly invite you to participate in this groundbreaking project and help shape the future of Mars colonization together.
+
+Thank you for your attention.
+
+**Questions and Answers**
+- Open Q&A session for the audience.
+
+**Closing Remarks**
+- Thank you and invitation for further discussions and collaborations.
+
+---
+**License:** CC BY 4.0
+**Disclaimer:** Portions of this document were generated with the assistance of GPT-4.

--- a/Habitats/MarsGummiHaus/publish/Entwurf_Gummi-Glashaus_Mars_DE.md
+++ b/Habitats/MarsGummiHaus/publish/Entwurf_Gummi-Glashaus_Mars_DE.md
@@ -1,0 +1,129 @@
+---
+title: "Entwurf eines 1000 m² Gummi-Glashauses für den Mars"
+author: "Robert Alexander Massinger"
+date: 2024-06-01
+keywords: [Mars, Habitat, Gummi-Glashaus, Architektur]
+abstract: |
+  Dieses Exposé beschreibt den Entwurf eines 1000 m² großen Gummi-Glashauses für den Mars. Das Konzept nutzt lokal produziertes Silikonkautschuk und eine Titan- oder Inconelstruktur mit Borosilikatglas. Ziel ist ein nachhaltiger, expandierbarer Lebensraum für zukünftige Marskolonien.
+license: CC BY 4.0
+---
+### Exposé: Entwurf eines 1000 m² Gummi-Glashauses für den Mars
+
+#### Einleitung
+
+Sehr geehrte Damen und Herren,
+
+der Mars stellt die nächste große Grenze der menschlichen Erforschung dar. Um die Besiedlung des Mars erfolgreich voranzutreiben, ist die Entwicklung innovativer, nachhaltiger und sicherer Lebensräume entscheidend. Wir präsentieren Ihnen ein einzigartiges Konzept: Ein 1000 m² großes Gummi-Glashaus, das speziell für die extremen Bedingungen des Mars entwickelt wurde. Dieses Projekt bietet eine außergewöhnliche Investitionsmöglichkeit in die Zukunft der Raumfahrt und der extraterrestrischen Kolonisierung.
+
+---
+
+#### 1. Konzept und Design
+
+##### Grundriss und Struktur
+- **Gesamtfläche**: 1000 m² (50 m x 20 m)
+- **Höhe**: 3 m, ausreichend für Wohn- und Arbeitsräume
+
+##### Materialien
+- **Gummibodenplatte und Gummigrundmauer**: Aus Silikonkautschuk vor Ort gegossen
+- **Rahmen**: Hochfeste Titan- oder Inconel-Struktur
+- **Verglasung**: Borosilikatglas mit Isolierschicht
+- **Dach**: Solarpaneele zur Energiegewinnung
+- **Druckschleuse**: Titan/Inconel-Konstruktion mit Borosilikatglas
+
+---
+
+#### 2. Detaillierte Beschreibung
+
+##### Gummibodenplatte und Gummigrundmauer
+- **Material**: Silikonkautschuk, um Flexibilität und Dichtheit zu gewährleisten
+- **Dimensionen**:
+  - Bodenplatte: 1000 m², Dicke 10 cm
+  - Grundmauer: Umfang 140 m, Höhe 50 cm, Dicke 10 cm
+- **Volumen**: 107 m³ Silikonkautschuk
+
+##### Titan- oder Inconel-Rahmen
+- **Gewicht**: 5500 kg inklusive Befestigungen (Nieten oder Schrauben)
+- **Vorteile**: Hervorragende Korrosionsbeständigkeit, hohe Festigkeit und thermische Stabilität
+
+##### Borosilikatglas mit Isolierschicht
+- **Fläche**: 1000 m²
+- **Gewicht**: 10,000 kg
+- **Beschichtungen**: Anti-Reflexions- und UV-Schutzbeschichtungen zur Verbesserung der Energieeffizienz und Haltbarkeit
+
+##### Solarpaneele auf dem Dach
+- **Fläche**: 1000 m²
+- **Energieerzeugung**: Stabil ca. 973,392 kWh pro Marsjahr, ausreichend zur Versorgung der Lebensräume und Systeme
+
+##### Druckschleuse
+- **Dimensionen**: 2 m x 2 m x 5 m
+- **Gewicht**: ca. 1000 kg
+- **Material**: Titan/Inconel und Borosilikatglas
+
+---
+
+#### 3. Interne Ausstattung
+
+##### Agrarflächen und CO₂-Wandlung
+- **Agrarfläche**: 50 m² pro Person, insgesamt 200 m² für eine vegane Ernährung
+- **Pflanzen**: Gemüse, Obst, Hülsenfrüchte, Getreide
+- **CO₂ zu O₂ Wandlung**: Pflanzen und Algenreaktoren, Fläche ca. 20 m²
+
+##### Wohnräume und Labore
+- **Aufteilung**: Wohnbereiche, Labore und Maschinenraum für bis zu 4 Personen
+- **Ausstattung**: Moderne Einrichtungen zur Sicherstellung des Lebensunterhalts und der Forschung
+
+---
+
+#### 4. Nachhaltigkeit und Effizienz
+
+##### Nutzung vor Ort herstellbarer Materialien
+- **Silikonkautschuk und Silikatglas**: Herstellung aus Marsgestein und Siliziumdioxid
+- **Metalle**: Langfristige Nutzung von Marsmineralien zur Gewinnung von Titan und Aluminium
+
+---
+
+#### 5. Kostenschätzung (ohne Transportkosten)
+
+- **Silikonkautschuk und Zusätze**: ca. $53,500
+- **Titan/Inconel Rahmen**: ca. $165,000
+- **Borosilikatglas**: ca. $500,000
+- **Solarpaneele**: ca. $200,000
+- **Druckschleuse**: ca. $100,000
+- **Gesamt (Materialien)**: ca. $1,018,500
+
+- **Fertigung und Montage**: ca. $300,000
+- **Tests und Validierung**: ca. $200,000
+- **Gesamtkosten**: ca. $1,518,500
+
+---
+
+#### 6. Marktpotenzial und Investitionsmöglichkeiten
+
+##### Vorteile für Investoren
+- **Technologieführerschaft**: Positionierung als Vorreiter in der Marskolonisation und Raumfahrttechnologie.
+- **Nachhaltigkeit**: Nutzung vor Ort verfügbarer Ressourcen reduziert langfristig die Kosten und Abhängigkeiten von Erdzulieferungen.
+- **Wachstumsmarkt**: Steigende Nachfrage nach extraterrestrischen Lebensräumen und Infrastruktur.
+
+##### Langfristige Vision
+- **Selbstversorgung**: Reduktion der Transportkosten durch vor Ort hergestellte Baumaterialien und Ressourcen.
+- **Expansion**: Möglichkeit zur Erweiterung des Projekts für größere Kolonien und kommerzielle Anwendungen.
+
+---
+
+#### 7. Fazit
+
+Das Gummi-Glashaus bietet eine zukunftsweisende Lösung für das Leben und Arbeiten auf dem Mars. Mit einer durchdachten Kombination aus fortschrittlichen Materialien und nachhaltigen Technologien stellt dieses Konzept einen bedeutenden Schritt in Richtung dauerhafter Marskolonien dar. Investoren haben die einmalige Gelegenheit, Teil eines revolutionären Projekts zu sein, das nicht nur die Marsforschung, sondern auch die gesamte Raumfahrtindustrie nachhaltig verändern wird.
+
+Wir laden Sie herzlich ein, sich an diesem bahnbrechenden Projekt zu beteiligen und gemeinsam die Zukunft der Marskolonisation zu gestalten.
+
+**Vielen Dank für Ihre Aufmerksamkeit.**
+
+**Fragen und Antworten**
+- Offene Fragerunde für das Publikum.
+
+**Schlusswort**
+- Danksagung und Einladung zu weiteren Diskussionen und Kooperationen.
+
+---
+**Lizenz:** CC BY 4.0
+**Disclaimer:** Teile dieses Dokuments wurden mit Unterstützung von GPT-4 erstellt.

--- a/Habitats/MarsGummiHaus/publish/SPRINT_RESULTS.md
+++ b/Habitats/MarsGummiHaus/publish/SPRINT_RESULTS.md
@@ -1,0 +1,17 @@
+# Ergebnisse der Sprintplanung
+
+## Sprint 1: Sichtung & Strukturierung
+- Alle Quelldokumente gesichtet und Dubletten geprüft.
+- Einheitliche Dateinamen und Release-Ordner `publish` erstellt.
+
+## Sprint 2: Inhaltliche & sprachliche Finalisierung
+- Rechtschreibung überprüft und YAML-Metadaten mit Abstract und Keywords ergänzt.
+- Lizenzinformationen und GPT-4-Disclaimer eingefügt.
+
+## Sprint 3: Formatierung & Zenodo-Kompatibilität
+- Überschriftenstruktur überprüft.
+- PDF-Versionen der Markdown-Dokumente mit `pandoc` und `xelatex` erzeugt.
+
+## Sprint 4: Veröffentlichungsvorbereitung
+- Alle finalen Dateien im Ordner `publish` abgelegt.
+- Dokumente bereit für Upload auf Zenodo und Verknüpfung mit englischer Folgepublikation.

--- a/Habitats/MarsGummiHaus/publish/The_Peoples_1000m2_Rubber-Glass_House_on_Mars_EN.md
+++ b/Habitats/MarsGummiHaus/publish/The_Peoples_1000m2_Rubber-Glass_House_on_Mars_EN.md
@@ -1,0 +1,159 @@
+---
+title: "The People’s 1000 m² Rubber-Glass House on Mars"
+author: "Robert Alexander Massinger"
+date: 2024-06-01
+keywords: [Mars, Rubber-Glass House, Community]
+abstract: |
+  This manifesto presents a vision for a 1000 m² rubber-glass house constructed largely from Martian materials. It emphasizes sustainability, local resource use, and community participation in the expansion of extraterrestrial habitats.
+license: CC BY 4.0
+---
+
+"The People’s 1000 m² Rubber-Glass House on Mars" by Robert Alexander Massinger and ChatGpt 3.5/4o, June 2024, The MIT License applies. 
+
+Idea and Concept:
+
+The concept of the rubber-glass house for Mars incorporates the innovative use of locally available silicate materials. By utilizing Martian rock and silicon dioxide, we can manufacture essential construction materials such as silicone rubber and borosilicate glass directly on Mars. This approach significantly reduces the dependency on imported materials from Earth, leading to substantial cost savings and promoting sustainability in the construction and maintenance of Martian habitats.
+
+The ability to produce critical building components on Mars not only enhances self-sufficiency but also supports the long-term vision of establishing a sustainable and expandable colony. By minimizing the need for Earth-based resources, we can focus on developing more extensive and resilient infrastructure on Mars, paving the way for future commercial and residential expansions.
+
+This use of silicate materials aligns with our commitment to sustainable practices and positions the rubber-glass house as a pioneering solution in extraterrestrial habitat construction. Investors can take pride in supporting a project that not only advances space exploration but also champions environmental responsibility and innovative resource management.
+
+
+Exposé: The People’s 1000 m² Rubber-Glass House on Mars
+
+Ladies and Gentlemen,
+
+Mars represents the next great frontier of human exploration. To successfully advance the colonization of Mars, the development of innovative, sustainable, and safe living spaces is crucial. We present to you a unique concept: The People’s 1000 m² Rubber-Glass House on Mars, specifically designed for the extreme conditions on Mars. This project offers an exceptional investment opportunity in the future of space travel and extraterrestrial colonization.
+
+1. Concept and Design
+
+Floor Plan and Structure:
+
+    Total area: 1000 m² (50 m x 20 m)
+    Height: 3 m, sufficient for living and working spaces
+
+Materials:
+
+    Rubber floor slab and rubber foundation wall: Cast on-site from silicone rubber
+    Frame: High-strength titanium or Inconel structure
+    Glazing: Borosilicate glass with an insulating layer
+    Roof: Solar panels for energy generation
+    Airlock: Titanium/Inconel construction with borosilicate glass
+
+2. Detailed Description
+
+Rubber Floor Slab and Rubber Foundation Wall:
+
+    Material: Silicone rubber to ensure flexibility and tightness
+    Dimensions:
+        Floor slab: 1000 m², thickness 10 cm
+        Foundation wall: Perimeter 140 m, height 50 cm, thickness 10 cm
+    Volume: 107 m³ of silicone rubber
+
+Titanium or Inconel Frame:
+
+    Weight: 5500 kg including fasteners (rivets or screws)
+    Advantages: Excellent corrosion resistance, high strength, and thermal stability
+
+Borosilicate Glass with Insulating Layer:
+
+    Area: 1000 m²
+    Weight: 10,000 kg
+    Coatings: Anti-reflection and UV protection coatings to improve energy efficiency and durability
+
+Solar Panels on the Roof:
+
+    Area: 1000 m²
+    Energy generation: Approximately 973,392 kWh per Martian year, sufficient to power the living spaces and systems
+
+Airlock:
+
+    Dimensions: 2 m x 2 m x 5 m
+    Weight: approximately 1000 kg
+    Material: Titanium/Inconel and borosilicate glass
+
+3. Interior Fittings
+
+Agricultural Areas and CO2 Conversion:
+
+    Agricultural area: 50 m² per person, total of 200 m² for a vegan diet
+    Plants: Vegetables, fruits, legumes, grains
+    CO2 to O2 conversion: Plants and algae reactors, area approx. 20 m²
+
+Living Spaces and Laboratories:
+
+    Layout: Living areas, laboratories, and machine room for up to 4 people
+    Equipment: Modern facilities to ensure sustenance and research
+
+4. Sustainability and Efficiency
+
+Use of Locally Manufactured Materials:
+
+    Silicone rubber and silicate glass: Produced from Martian rock and silicon dioxide
+    Metals: Long-term use of Martian minerals to extract titanium and aluminum
+
+5. Cost Estimate (excluding transport costs)
+
+    Silicone rubber and additives: approx. $53,500
+    Titanium/Inconel frame: approx. $165,000
+    Borosilicate glass: approx. $500,000
+    Solar panels: approx. $200,000
+    Airlock: approx. $100,000
+    Total (materials): approx. $1,018,500
+    Manufacturing and assembly: approx. $300,000
+    Testing and validation: approx. $200,000
+    Total cost: approx. $1,518,500
+
+6. Market Potential and Investment Opportunities
+
+Advantages for Investors:
+
+    Technological Leadership: Positioning as a pioneer in Mars colonization and space travel technology.
+    Sustainability: Use of locally available resources reduces long-term costs and dependencies on Earth suppliers.
+    Growth Market: Increasing demand for extraterrestrial habitats and infrastructure.
+
+Long-term Vision:
+
+    Self-Sufficiency: Reduction of transport costs through locally produced building materials and resources.
+    Expansion: Potential to expand the project for larger colonies and commercial applications.
+
+7. Conclusion
+
+The People’s 1000 m² Rubber-Glass House on Mars offers a forward-looking solution for living and working on Mars. With a well-thought-out combination of advanced materials and sustainable technologies, this concept represents a significant step towards permanent Mars colonies. Investors have the unique opportunity to be part of a revolutionary project that will not only advance Mars research but also sustainably transform the entire space industry.
+
+We warmly invite you to participate in this groundbreaking project and shape the future of Mars colonization together. Thank you for your attention.
+
+Questions and Answers:
+
+    Open Q&A session for the audience.
+
+Closing Remarks:
+
+    Thank you and invitation to further discussions and collaborations.
+	The MIT License applies. 
+
+MIT License
+
+Copyright (c) 2024 Robert Alexander Massinger, Munich, Germany.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+**License:** CC BY 4.0
+**Disclaimer:** Portions of this document were generated with the assistance of GPT-4.

--- a/Habitats/MarsGummiHaus/publish/Varianten_Gummi-Glashaus_Mars_DE.md
+++ b/Habitats/MarsGummiHaus/publish/Varianten_Gummi-Glashaus_Mars_DE.md
@@ -1,0 +1,83 @@
+---
+title: "Varianten des Gummi-Glashauses für den Mars"
+author: "Robert Alexander Massinger"
+date: 2024-06-01
+keywords: [Mars, Gummi-Glashaus, Varianten]
+abstract: |
+  Dieses Dokument stellt drei Varianten des Gummi-Glashauses vor und vergleicht Materialbedarf sowie bauliche Besonderheiten. Ziel ist die Auswahl einer optimalen Bauweise für nachhaltige Marskolonien.
+license: CC BY 4.0
+---
+### 1. Zwei-Stöckiges Gummi-Glashaus
+
+#### Grundriss und Struktur
+- **Gesamtfläche:** 1000 m² (50 m x 20 m) pro Stockwerk, insgesamt 2000 m²
+- **Höhe:** 6 m (3 m pro Stockwerk)
+- **Dach:** Flachdach
+
+#### Materialien
+- **Gummibodenplatte und Gummigrundmauer:** Aus Silikonkautschuk vor Ort gegossen
+- **Rahmen:** Hochfeste Titan- oder Inconel-Struktur
+- **Verglasung:** Borosilikatglas mit Isolierschicht
+- **Dach:** Solarpaneele zur Energiegewinnung
+- **Druckschleuse:** Titan/Inconel-Konstruktion mit Borosilikatglas
+
+#### Mengenkalkulation
+- **Gummibodenplatte und Grundmauer:** Doppelte Menge an Silikonkautschuk (214 m³)
+- **Rahmen:** Erhöhter Bedarf an Titan/Inconel (ca. 11,000 kg)
+- **Borosilikatglas:** 2000 m²
+- **Solarpaneele:** 1000 m²
+- **Druckschleuse:** 2 Einheiten
+
+### 2. Drei-Stöckiges Gummi-Glashaus mit Keller
+
+#### Grundriss und Struktur
+- **Gesamtfläche:** 1000 m² (50 m x 20 m) pro Stockwerk, insgesamt 3000 m²
+- **Höhe:** 9 m (3 m pro Stockwerk) plus Keller
+- **Keller:** Vollgummiert, gleiche Fläche wie das Erdgeschoss
+
+#### Materialien
+- **Gummibodenplatte und Gummigrundmauer:** Aus Silikonkautschuk vor Ort gegossen
+- **Rahmen:** Hochfeste Titan- oder Inconel-Struktur
+- **Verglasung:** Borosilikatglas mit Isolierschicht
+- **Dach:** Solarpaneele zur Energiegewinnung
+- **Druckschleuse:** Titan/Inconel-Konstruktion mit Borosilikatglas
+
+#### Mengenkalkulation
+- **Gummibodenplatte und Grundmauer:** Vierfache Menge an Silikonkautschuk (428 m³)
+- **Rahmen:** Erhöhter Bedarf an Titan/Inconel (ca. 16,500 kg)
+- **Borosilikatglas:** 3000 m²
+- **Solarpaneele:** 1000 m²
+- **Druckschleuse:** 3 Einheiten
+
+### 3. Zwei-Stöckiges Gummi-Glashaus mit Schrägdach
+
+#### Grundriss und Struktur
+- **Gesamtfläche:** 1000 m² (50 m x 20 m) pro Stockwerk, insgesamt 2000 m²
+- **Höhe:** 6 m (3 m pro Stockwerk) plus Schrägdach
+- **Dach:** Schrägdach
+
+#### Materialien
+- **Gummibodenplatte und Gummigrundmauer:** Aus Silikonkautschuk vor Ort gegossen
+- **Rahmen:** Hochfeste Titan- oder Inconel-Struktur
+- **Verglasung:** Borosilikatglas mit Isolierschicht
+- **Dach:** Solarpaneele zur Energiegewinnung, angepasst an Schrägdach
+- **Druckschleuse:** Titan/Inconel-Konstruktion mit Borosilikatglas
+
+#### Mengenkalkulation
+- **Gummibodenplatte und Grundmauer:** Doppelte Menge an Silikonkautschuk (214 m³)
+- **Rahmen:** Erhöhter Bedarf an Titan/Inconel (ca. 11,000 kg)
+- **Borosilikatglas:** 2000 m²
+- **Solarpaneele:** 1000 m², angepasst an die Neigung des Dachs
+- **Druckschleuse:** 2 Einheiten
+
+### Fazit
+
+Jede dieser Varianten bietet spezifische Vorteile und Herausforderungen in Bezug auf Bau, Materialien und Energieeffizienz. Die Entscheidung für eine der Varianten sollte auf Grundlage der spezifischen Anforderungen, der Verfügbarkeit von Ressourcen und der langfristigen Pläne für die Marskolonisation getroffen werden.
+
+Diese Varianten berücksichtigen die Nutzung vor Ort verfügbarer Materialien und nachhaltige Bauweisen, um die Kosten und die Abhängigkeit von Transporten von der Erde zu minimieren. 
+
+Falls du weitere Details oder eine PDF-Version dieser Varianten benötigst, lasse es mich bitte wissen.
+
+---
+**Lizenz:** CC BY 4.0
+**Disclaimer:** Teile dieses Dokuments wurden mit Unterstützung von GPT-4 erstellt.


### PR DESCRIPTION
## Summary
- delete generated PDFs from `publish` to keep only text files

## Testing
- `pandoc Habitats/MarsGummiHaus/publish/Entwurf_Gummi-Glashaus_Mars_DE.md -o /tmp/test.pdf --pdf-engine=xelatex`

------
https://chatgpt.com/codex/tasks/task_e_6884dfd8e160832ab0126bea4b606ccf