### PR TITLE
Add workflow to build PDF artifacts from publish markdown

### DIFF
--- a/.github/workflows/convert_publish_markdown_to_pdf.yml
+++ b/.github/workflows/convert_publish_markdown_to_pdf.yml
@@ -24,7 +24,7 @@ jobs:
           done
 
       - name: Upload PDFs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: publish-pdfs
           path: Habitats/MarsGummiHaus/publish/*.pdf

--- a/.github/workflows/convert_publish_markdown_to_pdf.yml
+++ b/.github/workflows/convert_publish_markdown_to_pdf.yml
@@ -13,8 +13,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install pandoc and pdflatex
-        run: sudo apt-get update && sudo apt-get install -y pandoc texlive-latex-base
+      - name: Install Pandoc and LaTeX packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc texlive-latex-base texlive-latex-recommended texlive-fonts-recommended
 
       - name: Convert Markdown files to PDF
         run: |

--- a/.github/workflows/convert_publish_markdown_to_pdf.yml
+++ b/.github/workflows/convert_publish_markdown_to_pdf.yml
@@ -13,8 +13,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install pandoc
-        run: sudo apt-get update && sudo apt-get install -y pandoc
+      - name: Install pandoc and pdflatex
+        run: sudo apt-get update && sudo apt-get install -y pandoc texlive-latex-base
 
       - name: Convert Markdown files to PDF
         run: |

--- a/.github/workflows/convert_publish_markdown_to_pdf.yml
+++ b/.github/workflows/convert_publish_markdown_to_pdf.yml
@@ -1,0 +1,31 @@
+name: Convert publish Markdown to PDF
+
+on:
+  push:
+    paths:
+      - '**/publish/**.md'
+      - '.github/workflows/convert_publish_markdown_to_pdf.yml'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Install pandoc
+        run: sudo apt-get update && sudo apt-get install -y pandoc
+
+      - name: Convert Markdown files to PDF
+        run: |
+          for file in Habitats/MarsGummiHaus/publish/*.md; do
+            [ -f "$file" ] || continue
+            pandoc "$file" -o "${file%.md}.pdf"
+          done
+
+      - name: Upload PDFs
+        uses: actions/upload-artifact@v3
+        with:
+          name: publish-pdfs
+          path: Habitats/MarsGummiHaus/publish/*.pdf
+          if-no-files-found: warn

--- a/.github/workflows/convert_publish_markdown_to_pdf.yml
+++ b/.github/workflows/convert_publish_markdown_to_pdf.yml
@@ -16,7 +16,14 @@ jobs:
       - name: Install Pandoc and LaTeX packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y pandoc texlive-latex-base texlive-latex-recommended texlive-fonts-recommended
+          sudo apt-get install -y pandoc texlive-latex-base texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra
+
+      - name: Replace Unicode subscripts with LaTeX
+        run: |
+          for file in Habitats/MarsGummiHaus/publish/*.md; do
+            [ -f "$file" ] || continue
+            sed -i -E 's/₀/$_0$/g; s/₁/$_1$/g; s/₂/$_2$/g; s/₃/$_3$/g; s/₄/$_4$/g; s/₅/$_5$/g; s/₆/$_6$/g; s/₇/$_7$/g; s/₈/$_8$/g; s/₉/$_9$/g' "$file"
+          done
 
       - name: Convert Markdown files to PDF
         run: |


### PR DESCRIPTION
## Summary
- automate conversion of Markdown files in `publish` to PDFs
- upload converted PDFs as workflow artifacts on every push

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68861432e2e8832aa6a9d7f92a75b83a