### PR TITLE
Fix PDF conversion workflow using xelatex

### DIFF
--- a/.github/workflows/convert_publish_markdown_to_pdf.yml
+++ b/.github/workflows/convert_publish_markdown_to_pdf.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Pandoc and LaTeX packages
         run: |
           sudo apt-get update
-          sudo apt-get install -y pandoc texlive-latex-base texlive-latex-recommended texlive-fonts-recommended texlive-latex-extra
+          sudo apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-latex-extra
 
       - name: Replace Unicode subscripts with LaTeX
         run: |
@@ -29,7 +29,7 @@ jobs:
         run: |
           find publish -path '*/docs/*.md' -type f -print0 |
           while IFS= read -r -d '' file; do
-            pandoc "$file" -o "${file%.md}.pdf"
+            pandoc "$file" -o "${file%.md}.pdf" --pdf-engine=xelatex
           done
 
       - name: Upload PDFs


### PR DESCRIPTION
## Summary
- use `texlive-xetex` instead of the base LaTeX packages
- call pandoc with `--pdf-engine=xelatex`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68864f41e378832a91a52201b0983a7e