### PR TITLE
Fix CJK latex dependencies

### DIFF
--- a/.github/workflows/convert_publish_markdown_to_pdf.yml
+++ b/.github/workflows/convert_publish_markdown_to_pdf.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Pandoc, LaTeX and emoji fonts
         run: |
           sudo apt-get update
-          sudo apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-latex-extra fonts-dejavu-core
+          sudo apt-get install -y pandoc texlive-xetex texlive-fonts-recommended texlive-latex-extra texlive-lang-cjk fonts-dejavu-core
           sudo mkdir -p /usr/share/fonts/truetype/openmoji
           sudo wget -O /usr/share/fonts/truetype/openmoji/OpenMoji-black-glyf.ttf https://github.com/hfg-gmuend/openmoji/raw/master/font/OpenMoji-black-glyf/OpenMoji-black-glyf.ttf
           sudo wget -O /usr/share/fonts/truetype/openmoji/OpenMoji-color-glyf_colr_0.ttf https://github.com/hfg-gmuend/openmoji/raw/master/font/OpenMoji-color-glyf_colr_0/OpenMoji-color-glyf_colr_0.ttf
@@ -33,10 +33,11 @@ jobs:
         run: |
           find publish -path '*/docs/*.md' -type f -print0 |
           while IFS= read -r -d '' file; do
-            pandoc "$file" -o "${file%.md}.pdf" --pdf-engine=xelatex \
+            pandoc "$file" -o "${file%.md}.pdf" \
+              --pdf-engine=xelatex \
               -V mainfont="DejaVu Sans" \
-              -V CJKmainfont="OpenMoji Color" \
-              -V monofont="DejaVu Sans Mono"
+              -V monofont="DejaVu Sans Mono" \
+              -V emoji="OpenMoji Color"
           done
 
       - name: Upload PDFs


### PR DESCRIPTION
## Summary
- install `texlive-lang-cjk` in the PDF build workflow so `xeCJK.sty` is found
- replace `CJKmainfont` with `emoji` variable when generating PDFs

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68865bb70ab0832a94cb82b30dbb0a37