### PR TITLE
Fix GitHub Action

### DIFF
--- a/.github/workflows/convert_publish_markdown_to_pdf.yml
+++ b/.github/workflows/convert_publish_markdown_to_pdf.yml
@@ -31,13 +31,9 @@ jobs:
 
       - name: Convert Markdown files to PDF
         run: |
-          # Ask pandoc where it actually keeps its default filters
-          FILTER="$(pandoc --print-default-data-file=filters/pandoc-emoji.lua)"
-          echo "Using emoji filter at $FILTER"
           find publish -path '*/docs/*.md' -type f -print0 |
           while IFS= read -r -d '' file; do
-            pandoc "$file" -o "${file%.md}.pdf" \        
-            --lua-filter "$FILTER" \
+            pandoc "$file" -o "${file%.md}.pdf" \
             --pdf-engine=lualatex \
             -V mainfont="DejaVu Sans" \
             -V monofont="DejaVu Sans Mono" \


### PR DESCRIPTION
## Summary
- fix the `convert_publish_markdown_to_pdf` workflow by removing the missing emoji filter

## Testing
- `pandoc -o /tmp/out.pdf --lua-filter missingfilter.lua /dev/null && echo OK || echo fail`

------
https://chatgpt.com/codex/tasks/task_e_6886797123bc832abd8dc1d9efd8bcdc