### PR TITLE
Switch to black emoji in docs and workflow

### DIFF
--- a/.github/workflows/convert_publish_markdown_to_pdf.yml
+++ b/.github/workflows/convert_publish_markdown_to_pdf.yml
@@ -19,7 +19,7 @@ jobs:
           sudo apt-get install -y pandoc texlive-luatex texlive-fonts-recommended texlive-latex-extra texlive-lang-cjk fonts-dejavu-core
           sudo mkdir -p /usr/share/fonts/truetype/openmoji
           sudo wget -O /usr/share/fonts/truetype/openmoji/OpenMoji-black-glyf.ttf https://github.com/hfg-gmuend/openmoji/raw/master/font/OpenMoji-black-glyf/OpenMoji-black-glyf.ttf
-          sudo wget -O /usr/share/fonts/truetype/openmoji/OpenMojiColorEmoji.ttf https://github.com/hfg-gmuend/openmoji/raw/master/font/OpenMoji-color-glyf_colr_0/OpenMoji-color-glyf_colr_0.ttf
+          # Install only the monochrome emoji font
           sudo fc-cache -f -v
 
       - name: Replace Unicode subscripts with LaTeX
@@ -42,10 +42,10 @@ jobs:
             --pdf-engine=lualatex \
             -V mainfont="DejaVu Sans" \
             -V monofont="DejaVu Sans Mono" \
-            -V emoji="OpenMojiColorEmoji.ttf" \
+            -V emoji="OpenMoji-black-glyf.ttf" \
             --lua-filter=latex-emoji.lua \
-            -M emojifont="OpenMojiColorEmoji.ttf" \
-            -M color=true
+            -M emojifont="OpenMoji-black-glyf.ttf" \
+            -M color=false
           done
 
       - name: Upload PDFs

--- a/publish/AGENTS.md
+++ b/publish/AGENTS.md
@@ -1,0 +1,20 @@
+# Publication Markdown Style Guide
+
+This guide defines the formatting rules for all `publish/*/docs/*.md` files.
+
+## Emoji usage
+- Use only monochrome symbols supported by the fonts `DejaVu Sans` and `OpenMoji-black-glyf`.
+- Preferred replacements:
+  - `✓` for check marks
+  - `⚙` for notes or asides
+  - `☘` to denote growth or sustainability
+  - `⚛` for scientific or DNA references
+  - `♁` for planet Earth
+- Avoid coloured emoji.
+
+## General rules
+- Files must start with a level‑1 heading (`# Title`).
+- Use normal Markdown lists using `-` or numbered lists with `1.`.
+- Provide alt text for images.
+- Include a `License` section referencing CC BY 4.0 if applicable.
+- End with a `Disclaimer` section when needed.

--- a/publish/habitats/three-step-evolution-towards-biomimetic-and-self-growing-structures/docs/Three-Step Evolution Towards Biomimetic and Self-Growing Structures.md
+++ b/publish/habitats/three-step-evolution-towards-biomimetic-and-self-growing-structures/docs/Three-Step Evolution Towards Biomimetic and Self-Growing Structures.md
@@ -73,16 +73,16 @@ This “Old School” step serves as the **launchpad for Martian infrastructure*
 
 ### Advantages
 
-- ✅ **Mature and reliable materials**: All components are space-grade or well understood in aerospace applications.
-- ✅ **Fast-track deployment**: This design can be constructed with existing manufacturing infrastructure on Earth.
-- ✅ **Robust against harsh conditions**: Resists Martian dust storms, radiation, and thermal extremes.
+- ✓ **Mature and reliable materials**: All components are space-grade or well understood in aerospace applications.
+- ✓ **Fast-track deployment**: This design can be constructed with existing manufacturing infrastructure on Earth.
+- ✓ **Robust against harsh conditions**: Resists Martian dust storms, radiation, and thermal extremes.
 
 ### Challenges
 
 - ⚠️ **High mass and volume**: Shipping heavy structural components from Earth increases cost and logistical complexity.
 - ⚠️ **Thermal inefficiency**: Additional insulation or heating systems are required to maintain livable interior temperatures during Mars nights and winters.
 
-> 🧠 *This step lays the groundwork for more adaptive systems. Its reliability provides a testing ground for future iterations that embrace biomimetic and self-growing properties.*
+> ⚙ *This step lays the groundwork for more adaptive systems. Its reliability provides a testing ground for future iterations that embrace biomimetic and self-growing properties.*
 
 ---
 
@@ -112,9 +112,9 @@ The design principle is simple: mimic nature’s way of distributing mechanical 
 
 ### Advantages
 
-- ✅ **Mass reduction**: Silica aerogel reduces launch weight dramatically, easing mission logistics.
-- ✅ **Thermal superiority**: Reduces energy costs by passively maintaining internal temperatures.
-- ✅ **Efficient strength**: Biomimetic webs provide reinforcement precisely where needed — no excess mass.
+- ✓ **Mass reduction**: Silica aerogel reduces launch weight dramatically, easing mission logistics.
+- ✓ **Thermal superiority**: Reduces energy costs by passively maintaining internal temperatures.
+- ✓ **Efficient strength**: Biomimetic webs provide reinforcement precisely where needed — no excess mass.
 
 ### Challenges
 
@@ -122,7 +122,7 @@ The design principle is simple: mimic nature’s way of distributing mechanical 
 - ⚠️ **Complex integration**: Merging silicon webs into the aerogel matrix requires cutting-edge fabrication — not yet space-proven.
 - ⚠️ **Atmospheric pressure stress**: Mars’ thin atmosphere creates a large pressure differential — reinforcement must prevent implosion while staying lightweight.
 
-> 🌱 *Step 2 marks the beginning of biologically inspired engineering on Mars — where material follows function, and design learns from evolution.*
+> ☘ *Step 2 marks the beginning of biologically inspired engineering on Mars — where material follows function, and design learns from evolution.*
 
 ---
 
@@ -156,9 +156,9 @@ This marks a shift from “hardware deployment” to **architectural emergence**
 
 ### Advantages
 
-- ✅ **Dynamic expansion**: Structures can grow with the colony — adding living space, storage, or shielding as needed.
-- ✅ **Self-maintenance**: Reduces need for human repair missions; increases safety and mission duration.
-- ✅ **Sustainability**: Uses Martian raw materials to generate habitat mass — lowering costs and enabling independence.
+- ✓ **Dynamic expansion**: Structures can grow with the colony — adding living space, storage, or shielding as needed.
+- ✓ **Self-maintenance**: Reduces need for human repair missions; increases safety and mission duration.
+- ✓ **Sustainability**: Uses Martian raw materials to generate habitat mass — lowering costs and enabling independence.
 
 ### Challenges
 
@@ -166,7 +166,7 @@ This marks a shift from “hardware deployment” to **architectural emergence**
 - ⚠️ **Control and containment**: Autonomous systems must be tightly governed to prevent runaway growth or malfunction.
 - ⚠️ **Ethical and regulatory concerns**: Self-evolving architecture may blur lines between machine and life — prompting new frameworks for safety and rights.
 
-> 🧬 *Step 3 imagines habitats that aren’t just built — they’re alive. They learn, grow, and repair themselves — transforming Mars into a place not merely visited, but inhabited.*
+> ⚛ *Step 3 imagines habitats that aren’t just built — they’re alive. They learn, grow, and repair themselves — transforming Mars into a place not merely visited, but inhabited.*
 
 ---
 
@@ -184,7 +184,7 @@ Each step builds upon the last — not by discarding what came before, but by de
 
 In the long view, **the line between structure and organism may dissolve**. Future Mars habitats might pulse with regenerative energy, expand with their communities, and adapt like ecosystems. They will not merely shield life — they will be part of it.
 
-> 🌍 *What begins as shelter may evolve into habitat. What evolves into habitat may one day become home.*
+> ♁ *What begins as shelter may evolve into habitat. What evolves into habitat may one day become home.*
 
 ---
 


### PR DESCRIPTION
## Summary
- use black-and-white emoji in the `Three-Step Evolution...` paper
- add publication style guide with font-safe emoji list
- adjust GitHub workflow to render PDFs using the black OpenMoji font

## Testing
- `pandoc publish/habitats/three-step-evolution-towards-biomimetic-and-self-growing-structures/docs/Three-Step\ Evolution\ Towards\ Biomimetic\ and\ Self-Growing\ Structures.md -o /tmp/test.pdf --pdf-engine=lualatex` *(fails: `unicode-math.sty` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887a48a04d0832a869b9c0d8b2bca58